### PR TITLE
RC1

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,11 @@ config.x.faucet_pipeline.manifest_path = Rails.root.join("my", "own", "manifests
 
 The `manifest_path` is an absolute path.
 
+This gem also provides a Rake task `assets:precompile` that runs faucet with the
+`--compact --fingerprint` options. It can therefore be used as a drop-in replacement
+for the task provided by the Rails asset pipeline. It only works if you install
+your NPM dependencies to the default location (your app's `node_modules` folder).
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. You can

--- a/README.md
+++ b/README.md
@@ -129,10 +129,10 @@ In this case, your `application.html.erb` would contain lines like these:
 You can change the path to the manifest file with the following configuration:
 
 ```ruby
-config.x.faucet_pipeline.manifest_path = File.join("my", "own", "manifests", "path.json")
+config.x.faucet_pipeline.manifest_path = Rails.root.join("my", "own", "manifests", "path.json")
 ```
 
-The `manifest_path` is relative to your Rails Root.
+The `manifest_path` is an absolute path.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -129,10 +129,10 @@ In this case, your `application.html.erb` would contain lines like these:
 You can change the path to the manifest file with the following configuration:
 
 ```ruby
-config.x.faucet_pipeline.manifest_path = Rails.root.join("my", "own", "manifests", "path.json")
+config.faucet_pipeline.manifest_path = Rails.root.join("my", "own", "manifests", "path.json")
 ```
 
-The `manifest_path` is an absolute path.
+Note that `manifest_path` is an absolute path.
 
 This gem also provides a Rake task `assets:precompile` that runs faucet with the
 `--compact --fingerprint` options. It can therefore be used as a drop-in replacement

--- a/README.md
+++ b/README.md
@@ -52,12 +52,6 @@ And then execute:
 $ bundle
 ```
 
-Or install it yourself as:
-
-```
-$ gem install faucet_pipeline_rails
-```
-
 After this, you can ditch sprockets (aka the classic Rails asset pipeline)
 for good. If you're on an existing Rails app, change the top of your
 `config/application.rb` from `require 'rails/all'` to:
@@ -82,40 +76,33 @@ For fresh apps, you can just skip sprockets with:
 
     rails new --skip-sprockets
 
+You also need to install `faucet-pipeline`.
+[Here are the instructions](http://www.faucet-pipeline.org)
+
 ## Configuration
 
-By default this gem assumes that your manifest files can be found in
-`public/assets/manifest.json`. This is a nice starting point for a
-`faucet.config.js`:
+This is a nice starting point for a `faucet.config.js`:
 
 ```js
-let path = require("path");
-
-let jsConfig = [{
-  source: "./app/assets/javascripts/application.js",
-  target: "./public/assets/javascripts/application.js"
-}];
-
-let sassConfig = [{
-  source: "./app/assets/stylesheets/application.scss",
-  target: "./public/assets/stylesheets/application.css"
-}];
-
-let staticConfig = [{
-  source: "./app/assets/images",
-  target: "./public/assets/images"
-}];
-
 module.exports = {
-  js: jsConfig,
-  sass: sassConfig,
-  static: staticConfig,
-  watchDirs: ["app/assets"],
+  js: [{
+    source: "./app/assets/javascripts/application.js",
+    target: "./public/assets/javascripts/application.js"
+  }],
+  sass: [{
+    source: "./app/assets/stylesheets/application.scss",
+    target: "./public/assets/stylesheets/application.css"
+  }],
+  static: [{
+    source: "./app/assets/images",
+    target: "./public/assets/images"
+  }],
   manifest: {
     file: "./public/assets/manifest.json",
-    key: (f, targetDir) => path.relative(targetDir, f),
-    value: f => `/${path.relative("public", f)}`
-  }
+    key: "short",
+    webRoot: "./public"
+  },
+  watchDirs: ["./app/assets"]
 };
 ```
 
@@ -126,10 +113,12 @@ In this case, your `application.html.erb` would contain lines like these:
 <%= javascript_include_tag 'application.js', 'data-turbolinks-track': 'reload' %>
 ```
 
-You can change the path to the manifest file with the following configuration:
+By default this gem assumes that your manifest files can be found in
+`public/assets/manifest.json`. You can change the path to the manifest
+file with the following configuration:
 
 ```ruby
-config.faucet_pipeline.manifest_path = Rails.root.join("my", "own", "manifests", "path.json")
+config.faucet_pipeline.manifest_path = Rails.root.join("manifest.json")
 ```
 
 Note that `manifest_path` is an absolute path.

--- a/lib/faucet_pipeline_rails/manifest.rb
+++ b/lib/faucet_pipeline_rails/manifest.rb
@@ -5,12 +5,17 @@ module FaucetPipelineRails
     include Singleton
 
     def fetch(asset_name)
-      parsed_manifest.fetch(asset_name)
+      manifest.fetch(asset_name)
     rescue KeyError
       raise "The asset '#{asset_name}' was not in the manifest"
     end
 
     private
+
+    def manifest
+      return parsed_manifest unless Rails.env.production?
+      @manifest ||= parsed_manifest
+    end
 
     def parsed_manifest
       JSON.parse(unparsed_manifest)

--- a/lib/faucet_pipeline_rails/manifest.rb
+++ b/lib/faucet_pipeline_rails/manifest.rb
@@ -30,8 +30,7 @@ module FaucetPipelineRails
     end
 
     def manifest_path
-      Rails.configuration.x.faucet_pipeline.manifest_path ||
-        Rails.root.join("public", "assets", "manifest.json")
+      Rails.configuration.faucet_pipeline.manifest_path
     end
   end
 end

--- a/lib/faucet_pipeline_rails/manifest.rb
+++ b/lib/faucet_pipeline_rails/manifest.rb
@@ -15,22 +15,18 @@ module FaucetPipelineRails
     def parsed_manifest
       JSON.parse(unparsed_manifest)
     rescue JSON::ParserError
-      raise "The manifest file '#{relative_manifest_path}' is invalid JSON"
+      raise "The manifest file '#{manifest_path}' is invalid JSON"
     end
 
     def unparsed_manifest
       File.read(manifest_path)
     rescue Errno::ENOENT
-      raise "The manifest file '#{relative_manifest_path}' is missing"
+      raise "The manifest file '#{manifest_path}' is missing"
     end
 
     def manifest_path
-      File.join(Rails.root, relative_manifest_path)
-    end
-
-    def relative_manifest_path
       Rails.configuration.x.faucet_pipeline.manifest_path ||
-        File.join("public", "assets", "manifest.json")
+        Rails.root.join("public", "assets", "manifest.json")
     end
   end
 end

--- a/lib/faucet_pipeline_rails/railtie.rb
+++ b/lib/faucet_pipeline_rails/railtie.rb
@@ -9,6 +9,11 @@ module FaucetPipelineRails
       end
     end
 
+    initializer "faucet_pipeline.configure_manifest_path" do |app|
+      config.faucet_pipeline = ActiveSupport::OrderedOptions.new
+      config.faucet_pipeline.manifest_path = app.root.join("public", "assets", "manifest.json")
+    end
+
     rake_tasks do
       namespace :assets do
         desc "Compile assets via faucet-pipeline"

--- a/lib/faucet_pipeline_rails/railtie.rb
+++ b/lib/faucet_pipeline_rails/railtie.rb
@@ -8,5 +8,14 @@ module FaucetPipelineRails
         Manifest.instance.fetch(source)
       end
     end
+
+    rake_tasks do
+      namespace :assets do
+        desc "Compile assets via faucet-pipeline"
+        task :precompile do
+          sh "./node_modules/.bin/faucet --compact --fingerprint"
+        end
+      end
+    end
   end
 end

--- a/lib/faucet_pipeline_rails/version.rb
+++ b/lib/faucet_pipeline_rails/version.rb
@@ -1,3 +1,3 @@
 module FaucetPipelineRails
-  VERSION = "1.0.0.rc0"
+  VERSION = "1.0.0.rc1"
 end

--- a/test/faucet_pipeline_rails_test.rb
+++ b/test/faucet_pipeline_rails_test.rb
@@ -2,10 +2,6 @@ require "test_helper"
 require "fileutils"
 
 class FaucetPipelineRails::Test < ActionDispatch::IntegrationTest
-  def setup
-    Dummy::Application.config.x.faucet_pipeline.manifest_path = nil
-  end
-
   def test_that_the_source_of_an_image_is_set_correctly
     use_assets_fixtures "good_assets"
     get "/fancy/index"
@@ -61,10 +57,10 @@ class FaucetPipelineRails::Test < ActionDispatch::IntegrationTest
 
   def test_configure_different_manifest_path
     use_assets_fixtures "good_assets", asset_path: "test/dummy/public/myassets"
-    use_manifest_path File.join(Rails.root, "public", "myassets", "manifest.json")
-
-    assert_nothing_raised do
-      get "/fancy/index"
+    use_manifest_path(Rails.root.join("public", "myassets", "manifest.json")) do
+      assert_nothing_raised do
+        get "/fancy/index"
+      end
     end
   end
 
@@ -80,6 +76,9 @@ class FaucetPipelineRails::Test < ActionDispatch::IntegrationTest
   end
 
   def use_manifest_path(path)
-    Dummy::Application.config.x.faucet_pipeline.manifest_path = path
+    original_path = Dummy::Application.config.faucet_pipeline.manifest_path
+    Dummy::Application.config.faucet_pipeline.manifest_path = path
+    yield
+    Dummy::Application.config.faucet_pipeline.manifest_path = original_path
   end
 end

--- a/test/faucet_pipeline_rails_test.rb
+++ b/test/faucet_pipeline_rails_test.rb
@@ -46,7 +46,7 @@ class FaucetPipelineRails::Test < ActionDispatch::IntegrationTest
       get "/fancy/index"
     end
 
-    assert_equal err.message, "The manifest file 'public/assets/manifest.json' is missing", "Check for descriptive error message"
+    assert_match %r{The manifest file '.+/public/assets/manifest.json' is missing}, err.message, "Check for descriptive error message"
   end
 
   def test_raises_an_error_when_manifest_is_invalid_json
@@ -56,12 +56,12 @@ class FaucetPipelineRails::Test < ActionDispatch::IntegrationTest
       get "/fancy/index"
     end
 
-    assert_equal err.message, "The manifest file 'public/assets/manifest.json' is invalid JSON", "Check for descriptive error message"
+    assert_match %r{The manifest file '.+/public/assets/manifest.json' is invalid JSON}, err.message, "Check for descriptive error message"
   end
 
   def test_configure_different_manifest_path
     use_assets_fixtures "good_assets", asset_path: "test/dummy/public/myassets"
-    use_manifest_path File.join("public", "myassets", "manifest.json")
+    use_manifest_path File.join(Rails.root, "public", "myassets", "manifest.json")
 
     assert_nothing_raised do
       get "/fancy/index"


### PR DESCRIPTION
This is supposed to be the last release candidate before we release 1.0.0 of all faucet packages:

* [x] #3 
* [x] #5 
* [x] #6 
* [x] Breaking Change: More idiomatic way of configuring the manifest path
* [x] Adjust the example faucet.config.js to the new, smaller manifest configuration