### PR TITLE
Make manifest_path actually configurable during boot

### DIFF
--- a/lib/faucet_pipeline_rails/railtie.rb
+++ b/lib/faucet_pipeline_rails/railtie.rb
@@ -2,6 +2,8 @@ require "faucet_pipeline_rails/manifest"
 
 module FaucetPipelineRails
   class Railtie < Rails::Railtie
+    config.faucet_pipeline = ActiveSupport::OrderedOptions.new
+
     ActiveSupport.on_load(:action_view) do
       # Overwrite `compute_asset_path` with our own implementation
       define_method(:compute_asset_path) do |source, _|
@@ -10,8 +12,7 @@ module FaucetPipelineRails
     end
 
     initializer "faucet_pipeline.configure_manifest_path" do |app|
-      config.faucet_pipeline = ActiveSupport::OrderedOptions.new
-      config.faucet_pipeline.manifest_path = app.root.join("public", "assets", "manifest.json")
+      app.config.faucet_pipeline.manifest_path ||= app.root.join("public", "assets", "manifest.json")
     end
 
     rake_tasks do

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -22,4 +22,3 @@ module Dummy
     # -- all .rb files in that directory are automatically loaded.
   end
 end
-

--- a/test/faucet_pipeline_rails_test.rb
+++ b/test/faucet_pipeline_rails_test.rb
@@ -55,15 +55,6 @@ class FaucetPipelineRails::Test < ActionDispatch::IntegrationTest
     assert_match %r{The manifest file '.+/public/assets/manifest.json' is invalid JSON}, err.message, "Check for descriptive error message"
   end
 
-  def test_configure_different_manifest_path
-    use_assets_fixtures "good_assets", asset_path: "test/dummy/public/myassets"
-    use_manifest_path(Rails.root.join("public", "myassets", "manifest.json")) do
-      assert_nothing_raised do
-        get "/fancy/index"
-      end
-    end
-  end
-
   def teardown
     FileUtils.remove_dir "test/dummy/public/assets", true
     FileUtils.remove_dir "test/dummy/public/myassets", true
@@ -73,12 +64,5 @@ class FaucetPipelineRails::Test < ActionDispatch::IntegrationTest
 
   def use_assets_fixtures(name, asset_path: "test/dummy/public/assets")
     FileUtils.cp_r "test/fixtures/#{name}", asset_path
-  end
-
-  def use_manifest_path(path)
-    original_path = Dummy::Application.config.faucet_pipeline.manifest_path
-    Dummy::Application.config.faucet_pipeline.manifest_path = path
-    yield
-    Dummy::Application.config.faucet_pipeline.manifest_path = original_path
   end
 end


### PR DESCRIPTION
While integrating the latest RC into our project I discovered that configuring the `manifest_path` doesn't work as intended. When loading the Rails application I get

```
ruby/2.4.0/gems/railties-5.1.6/lib/rails/railtie/configuration.rb:95:in `method_missing': undefined method `faucet_pipeline' for #<Rails::Application::Configuration:0x007f553ce62da8> (NoMethodError)
        from /var/fejo-code/fejo-next/config/application.rb:94:in `<class:Application>'
        from /var/fejo-code/fejo-next/config/application.rb:20:in `<module:FejoNext>'
        from /var/fejo-code/fejo-next/config/application.rb:19:in `<top (required)>'
```

Reason for this it `config/application.rb` (which sets a custom `manifest_path`) is loaded **before** initializers are run. And since defining the `config.faucet_pipeline` is happening in a initializer changing it won't work.

Additionally I use the `app.config` inside the block to define the default `manifest_path` instead of writing in `FaucetPipelineRails::Railtie.config`.

## Caveat

Previous tests for that feature were actually not testing the intended behavior
and thus we removed this test. And yes, we know the functionality is not tested
anymore.