### PR TITLE
Make sure to path `compute_asset_path` for all circumstances

### DIFF
--- a/lib/faucet_pipeline_rails/railtie.rb
+++ b/lib/faucet_pipeline_rails/railtie.rb
@@ -6,7 +6,7 @@ module FaucetPipelineRails
 
     ActiveSupport.on_load(:action_view) do
       # Overwrite `compute_asset_path` with our own implementation
-      define_method(:compute_asset_path) do |source, _|
+      ActionView::Helpers::AssetUrlHelper.define_method(:compute_asset_path) do |source, _|
         Manifest.instance.fetch(source)
       end
     end

--- a/test/faucet_pipeline_rails_test.rb
+++ b/test/faucet_pipeline_rails_test.rb
@@ -55,6 +55,16 @@ class FaucetPipelineRails::Test < ActionDispatch::IntegrationTest
     assert_match %r{The manifest file '.+/public/assets/manifest.json' is invalid JSON}, err.message, "Check for descriptive error message"
   end
 
+  def test_use_faucet_manifest_when_using_helper_directly
+    use_assets_fixtures "good_assets"
+
+    helpers = Class.new do
+      include ActionView::Helpers::AssetUrlHelper
+    end.new
+
+    assert_equal "/assets/images/magic-f67894a08006a2af9f5076180676323c.gif", helpers.asset_path("magic.gif")
+  end
+
   def teardown
     FileUtils.remove_dir "test/dummy/public/assets", true
     FileUtils.remove_dir "test/dummy/public/myassets", true


### PR DESCRIPTION
# Problem

The current implementation overrides `compute_asset_path` on `ActionView::Base`, which is fine during regular usage of asset helpers (i.e. in views). But if you need to access `ActionView::Helpers` _outside_ of a view this would not work as expected. Take something like this:

```ruby
class PonyLetterGenerator
  def data_for_letter
    {
	  text: "some text",
      image: helpers.image_url("pony_logo.png")
    }
  end

  private

  def helpers
    Helpers.instance
  end

   class Helpers
    include Singleton
    include ActionView::Helpers
  end

  private_constant :Helpers
end
```

Which is a common (or at least common enough) pattern to provide access to `ActionView::Helpers` outside of a request context.

In that case `ActionView::Base` isn't loaded and thus our `compute_asset_path` isn't used.

## Solution

Override `compute_asset_path` in the `ActionView::Base::AssetUrlHelper` module to make it always available.